### PR TITLE
add Future Programming Workshop video to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
         <h1 id="project_title">Lamdu</h1>
         <h2 id="project_tagline">Lamdu - towards a new programming experience</h2>
 
+        <iframe src="https://player.vimeo.com/video/97713439" width="640" height="360" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
       </header>
     </div>
 


### PR DESCRIPTION
I've known about Lamdu for a year or so but I haven't looked into it much because it seemed like a lot to install (I've spent the last hour or two installing it). However, while things were installing, I did some google searching and came upon this wonderful video. I was blown away! 

While I am probably going overboard putting the video so front-and-center, I do believe it deserves a spot on your webpage.

[You can see what I'm proposing here](https://cdn.rawgit.com/stevekrouse/lamdu.github.io/ca5428e874405b4761a01f38a8aef92bdda1ea63/index.html):

![screenshot 2017-07-19 at 4 44 49 pm](https://user-images.githubusercontent.com/2288939/28388738-ae0690dc-6ca1-11e7-8fb7-240d6e643a94.png)
